### PR TITLE
fix testing of git directory on MSWin32

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+        - improved testing of git directories under MSWin32
 
 0.006     2015-08-01 22:01:34-04:00 America/New_York
         - remove fatal warnings from the test suite (future proofing)

--- a/t/lib/GitSetup.pm
+++ b/t/lib/GitSetup.pm
@@ -20,13 +20,15 @@ sub no_git_tempdir
 
     {
         my $in_git;
-        my $rootdir = Path::Tiny->rootdir;
         my $dir = $tempdir;
         my $count = 0;
-        while ($dir ne $rootdir and $count < 100) {
+        while (not $dir->is_rootdir) {
+            # this should never happen.
+            do { diag "failed to detect that $dir is at the root?!"; last } if $dir eq $dir->parent;
+
             my $checkdir = path($dir, '.git');
             if (-d $checkdir) {
-                diag "found $checkdir in $tempdir";
+                note "found $checkdir in $tempdir";
                 $in_git = 1;
                 last;
             }


### PR DESCRIPTION
The rootdir on MSWin32 is "C:/", which will never equal "/" after recursing
upwards.

See also
https://github.com/karenetheridge/Dist-Zilla-Plugin-Git-Contributors/pull/5
where this fix was originally made.