### PR TITLE
Fix bug: Git is not completely isolated

### DIFF
--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -29,8 +29,20 @@ my $git = git_wrapper($root);
 
 my $changes = $root->child('Changes');
 $changes->spew("Release history for my dist\n\n");
-$git->add('Changes');
-$git->commit({ message => 'first commit', author => 'Hey Jude <jude@example.org>' });
+
+{
+    # Make sure the git messages come in English. (LC_ALL)
+    # Eliminate the effects of system wide (GIT_CONFIG_NOSYSTEM)
+    # and global configuration (XDG_CONFIG_HOME and HOME).
+    # https://metacpan.org/dist/Git-Repository/view/lib/Git/Repository/Tutorial.pod#Ignore-the-system-and-global-configuration-files
+    local $ENV{LC_ALL} = 'C';
+    local $ENV{GIT_CONFIG_NOSYSTEM} = '1';
+    local $ENV{XDG_CONFIG_HOME} = undef;
+    local $ENV{HOME} = undef;
+
+    $git->add('Changes');
+    $git->commit({ message => 'first commit', author => 'Hey Jude <jude@example.org>' });
+}
 
 $tzil->chrome->logger->set_debug(1);
 

--- a/t/02-with-version.t
+++ b/t/02-with-version.t
@@ -35,8 +35,19 @@ my $git = git_wrapper($root);
 
 my $changes = $root->child('Changes');
 $changes->spew("Release history for my dist\n\n");
-$git->add('Changes');
-$git->commit({ message => 'first commit', author => 'Hey Jude <jude@example.org>' });
+{
+    # Make sure the git messages come in English. (LC_ALL)
+    # Eliminate the effects of system wide (GIT_CONFIG_NOSYSTEM)
+    # and global configuration (XDG_CONFIG_HOME and HOME).
+    # https://metacpan.org/dist/Git-Repository/view/lib/Git/Repository/Tutorial.pod#Ignore-the-system-and-global-configuration-files
+    local $ENV{LC_ALL} = 'C';
+    local $ENV{GIT_CONFIG_NOSYSTEM} = '1';
+    local $ENV{XDG_CONFIG_HOME} = undef;
+    local $ENV{HOME} = undef;
+
+    $git->add('Changes');
+    $git->commit({ message => 'first commit', author => 'Hey Jude <jude@example.org>' });
+}
 
 $tzil->chrome->logger->set_debug(1);
 

--- a/t/03-on-package-line.t
+++ b/t/03-on-package-line.t
@@ -29,8 +29,19 @@ my $git = git_wrapper($root);
 
 my $changes = $root->child('Changes');
 $changes->spew("Release history for my dist\n\n");
-$git->add('Changes');
-$git->commit({ message => 'first commit', author => 'Hey Jude <jude@example.org>' });
+{
+    # Make sure the git messages come in English. (LC_ALL)
+    # Eliminate the effects of system wide (GIT_CONFIG_NOSYSTEM)
+    # and global configuration (XDG_CONFIG_HOME and HOME).
+    # https://metacpan.org/dist/Git-Repository/view/lib/Git/Repository/Tutorial.pod#Ignore-the-system-and-global-configuration-files
+    local $ENV{LC_ALL} = 'C';
+    local $ENV{GIT_CONFIG_NOSYSTEM} = '1';
+    local $ENV{XDG_CONFIG_HOME} = undef;
+    local $ENV{HOME} = undef;
+
+    $git->add('Changes');
+    $git->commit({ message => 'first commit', author => 'Hey Jude <jude@example.org>' });
+}
 
 $tzil->chrome->logger->set_debug(1);
 


### PR DESCRIPTION
* GIT_CONFIG_NOSYSTEM prevents Git from reading system wide config, normally `/etc/gitconfig`
* Undef XDG_CONFIG_HOME to prevent Git from reading $HOME/.config/git/config.
* Undef HOME to prevent Git from reading $HOME/gitconfig

I came across this problem (and solution) because I have set user.signingkey in my $HOME/gitconfig. I like to sign all my commits with PGP. During installation of Git::Hooks, system started to demand my PGP key. Pretty scary!

Signed-off-by: Mikko Koivunalho <mikkoi@cpan.org>