### PR TITLE
Try::Tiny hasn't been used since 2012 (!)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+        - remove unneeded dependency on Try::Tiny
 
 0.008     2022-12-31 17:08:07-05:00 America/New_York
         - improve isolation of test git process (thanks, Mikko Koivunalho!)

--- a/lib/Dist/Zilla/Plugin/Git/Describe.pm
+++ b/lib/Dist/Zilla/Plugin/Git/Describe.pm
@@ -8,7 +8,6 @@ with(
 );
 
 use Git::Wrapper;
-use Try::Tiny;
 use List::Util 1.33 'all';
 
 use namespace::autoclean;


### PR DESCRIPTION
This has no consequences since Try::Tiny is pulled in by so many other things, but \<shrug\>